### PR TITLE
feat: 알림 삭제 기능 추가 및 헤더 와 알림창의 로그인 상태 일관성 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "cross-env": "^7.0.3",
         "cypress": "^13.13.0",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^8",
@@ -4464,24 +4463,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/src/app/api/create-notification/route.ts
+++ b/src/app/api/create-notification/route.ts
@@ -14,7 +14,7 @@ export const POST = async (request: Request) => {
       const timestamp = Date.now()
 
       usersSnapshot.forEach(async (doc) => {
-        const uid = doc.id
+        const uid = doc.id // user의 uid
         const newNotificationRef = ref(database, `notifications/${uid}/${timestamp}`)
         await set(newNotificationRef, {
           title,

--- a/src/app/api/delete-notification/route.ts
+++ b/src/app/api/delete-notification/route.ts
@@ -1,0 +1,17 @@
+import { database } from '@root/firebase'
+import { ref, remove } from 'firebase/database'
+import { NextResponse } from 'next/server'
+
+export const DELETE = async (request: Request) => {
+  try {
+    const { uid, notificationId } = await request.json()
+
+    const notificationRef = ref(database, `notifications/${uid}/${notificationId}`)
+    await remove(notificationRef)
+
+    return NextResponse.json({ message: 'Notification deleted successfully' })
+  } catch (error) {
+    console.error('Error deleting notifications:', error)
+    return NextResponse.json({ error: 'Error deleting notifications' }, { status: 500 })
+  }
+}

--- a/src/features/placeUpload/useImageUpload.ts
+++ b/src/features/placeUpload/useImageUpload.ts
@@ -2,10 +2,10 @@
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage'
 import { storage } from '@root/firebase'
 import { useState } from 'react'
-import { UserProfileType } from '@/hook/useCurrentAuth'
+import { IUserProfile } from '@/interfaces/IUserProfile'
 
 interface Props {
-  userProfile: UserProfileType | null
+  userProfile: IUserProfile | null
   imageSetValue: (updatedImages: string[]) => void
   setFiles: (files: (prevFiles: File[]) => File[]) => void
 }

--- a/src/hook/useCurrentAuth.tsx
+++ b/src/hook/useCurrentAuth.tsx
@@ -3,15 +3,10 @@ import { useEffect, useState } from 'react'
 import { db, fireauth } from '@root/firebase'
 import { doc, getDoc } from 'firebase/firestore'
 import { onAuthStateChanged } from 'firebase/auth'
-
-export type UserProfileType = {
-  email: string
-  nickname: string
-  uid: string
-}
+import { IUserProfile } from '@/interfaces/IUserProfile'
 
 const useCurrentAuth = () => {
-  const [userProfile, setUserProfile] = useState<UserProfileType | null>(null)
+  const [userProfile, setUserProfile] = useState<IUserProfile | null>(null)
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(fireauth, async (user) => {

--- a/src/interfaces/IUserProfile.ts
+++ b/src/interfaces/IUserProfile.ts
@@ -1,0 +1,5 @@
+export type IUserProfile = {
+  email: string
+  nickname: string
+  uid: string
+} | null

--- a/src/shared/components/common/Header.tsx
+++ b/src/shared/components/common/Header.tsx
@@ -60,7 +60,7 @@ const Header = () => {
       </div>
       {showNotifications && (
         <div className='absolute right-0 top-[48px] w-[300px] bg-white shadow-lg'>
-          <PlaceNotification />
+          <PlaceNotification userProfile={userProfile} />
         </div>
       )}
     </header>


### PR DESCRIPTION
## Firebase Realtime Database를 이용한 알림 시스템 구현

### 1. 알림 생성

#### API 엔드포인트 (`api/create-notification`)
- 새로운 게시물이 등록될 때 모든 사용자에게 알림을 보내기 위해 Firestore에서 모든 사용자 문서(users 컬렉션)를 가져옵니다.

- 각 사용자의 고유 ID(uid)를 이용해 Realtime Database의 `notifications` 경로에 새로운 알림을 생성합니다.

### 2. 알림 삭제

#### API 엔드포인트 (`api/delete-notification`)
- 특정 사용자(uid)와 알림 ID(notificationId)를 받아 해당 알림을 삭제합니다.

```jsx
import { database } from '@root/firebase'
import { ref, remove } from 'firebase/database'
import { NextResponse } from 'next/server'

export const DELETE = async (request: Request) => {
  try {
    const { uid, notificationId } = await request.json()

    const notificationRef = ref(database, `notifications/${uid}/${notificationId}`)
    await remove(notificationRef)

    return NextResponse.json({ message: 'Notification deleted successfully' })
  } catch (error) {
    console.error('Error deleting notifications:', error)
    return NextResponse.json({ error: 'Error deleting notifications' }, { status: 500 })
  }
}
```

- 요청이 성공하면 서버는 성공 메시지를 반환하고, 실패하면 에러 메시지를 반환합니다.

#### 클라이언트 측 삭제 처리
- 사용자가 삭제 버튼을 클릭하면, handleDelete 함수가 호출되어 서버에 삭제 요청을 보냅니다.
- 요청이 성공하면, `onValue` 리스너가 데이터 변경을 감지하여 상태를 업데이트하기 때문에 별도로 상태를 수동으로 업데이트할 필요가 없습니다.

### 3. 클라이언트에서 알림 표시
#### 알림 컴포넌트 (PlaceNotification)
- 사용자가 로그인하면, Firebase Realtime Database에서 해당 사용자의 알림 데이터를 실시간으로 감지하여 상태(state)를 업데이트합니다.

- `onValue` 리스너를 사용하여 데이터 변경을 감지하고, 알림 데이터를 컴포넌트 상태로 설정합니다.

- 알림 목록을 렌더링하며, 각 알림 항목에는 삭제 버튼이 포함되어 있습니다.

- useEffect 함수 내에서 firebase/database의 onValue로 Firebase Realtime Database에서 데이터 변경 감지

```jsx
const PlaceNotification = ({ userProfile }: { userProfile: IUserProfile }) => {
  const [messages, setMessages] = useState<Notification[]>([])

useEffect(() => {
    if (!userProfile) return

    const notificationsRef = ref(database, `notifications/${userProfile.uid}`)
    onValue(notificationsRef, (snapshot) => {
      const data = snapshot.val()
      if (data) {
        const messagesArray: Notification[] = Object.entries(data).map(([key, value]: any) => ({
          ...value,
          key,
        }))
        setMessages(messagesArray)
      } else {
        setMessages([])
      }
    })
  }, [userProfile])
//생략
```

## 로그인 정보 일관성 유지하여 로그인이 안되었다는 UI 해결하기

### 문제 설명
헤더와 알림 컴포넌트가 각각 useCurrentAuth 훅을 사용하여 유저의 로그인 정보를 가져오면서, 데이터 로딩 시점에 따라 로그인이 안 되어 있다는 UI가 잠시 보이는 문제가 발생했습니다.

### useCurrentAuth 훅
useCurrentAuth 훅은 Firebase 인증 상태를 감지하고, 현재 로그인한 유저의 정보를 가져오는 커스텀 훅입니다. 이 훅은 유저의 로그인 상태가 변경될 때마다 호출되어 유저 프로필 정보를 업데이트합니다.

### 작동 방식
#### Firebase 인증 상태 감지: 
- onAuthStateChanged 함수를 사용하여 Firebase 인증 상태 변화를 감지

#### Firestore에서 유저 정보 가져오기: 
- 유저가 로그인되어 있을 경우, Firestore에서 해당 유저의 프로필 정보를 가져와 useState 상태를 업데이트

### 해결 방법
헤더 컴포넌트에서 한 번만 useCurrentAuth 훅을 사용하여 userProfile을 가져온 후, 이를 알림 컴포넌트에 props로 전달하여 동일한 값을 사용하게 했습니다. 이렇게 함으로써, 로그인 정보의 일관성을 유지하고, 데이터 로딩 시점의 불일치를 제거했습니다.